### PR TITLE
Upgrade to `2.3.0` and Refactor where Hosts are configured

### DIFF
--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fides
-version: 0.1.2
-appVersion: "2.2.0"
+version: 0.2.0
+appVersion: "2.3.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application
 keywords:

--- a/fides/templates/NOTES.txt
+++ b/fides/templates/NOTES.txt
@@ -1,9 +1,9 @@
 ■ Fides
 Version: {{ include "fides.dockerTag" . }}
 {{ if .Values.ingress.enabled }}
-Fides Admin UI: https://{{.Values.ingress.hosts.fides}}
+Fides Admin UI: https://{{.Values.fides.publicHostname}}
 {{- if .Values.privacyCenter.enabled }}
-Privacy Center: https://{{.Values.ingress.hosts.privacyCenter}}
+Privacy Center: https://{{.Values.privacyCenter.publicHostname}}
 {{- end }}
 {{- end }}
 {{ if .Release.IsInstall }}

--- a/fides/templates/NOTES.txt
+++ b/fides/templates/NOTES.txt
@@ -7,7 +7,8 @@ Privacy Center: https://{{.Values.privacyCenter.publicHostname}}
 {{- end }}
 {{- end }}
 {{ if .Release.IsInstall }}
-For more information, check out the following resources: 
-  - Configuration reference: https://ethyca.github.io/fides/installation/configuration/ 
+For more information, check out the following resources:
+  - Documentation and guides https://fid.es/docs
+  - Configuration reference: https://fid.es/config
   - Slack community: https://fid.es/slack
 {{- end }}

--- a/fides/templates/_helpers.tpl
+++ b/fides/templates/_helpers.tpl
@@ -128,6 +128,17 @@ Create the name of the config map to store the fides.toml file.
 {{- end }}
 
 {{/*
+List of CORS origins
+*/}}
+{{- define "fides.corsOrigins" -}}
+{{ $cors := list (printf "https://%s" .Values.privacyCenter.publicHostname | quote ) (printf "https://%s" .Values.fides.publicHostname | quote) }}
+{{- range .Values.fides.configuration.additionalCORSOrigins }}
+  {{- $cors = . | quote | append $cors }}
+{{- end }}
+{{ printf "[%s]" (join "," $cors) }}
+{{- end }}
+
+{{/*
 The set of environment variables for Fides and workers
 */}}
 {{- define "fides.env" -}}

--- a/fides/templates/_helpers.tpl
+++ b/fides/templates/_helpers.tpl
@@ -128,13 +128,14 @@ Create the name of the config map to store the fides.toml file.
 {{- end }}
 
 {{/*
-List of CORS origins
+List of CORS origins, concatenated, deduplicated, and formatted.
 */}}
 {{- define "fides.corsOrigins" -}}
 {{ $cors := list (printf "https://%s" .Values.privacyCenter.publicHostname | quote ) (printf "https://%s" .Values.fides.publicHostname | quote) }}
-{{- range .Values.fides.configuration.additionalCORSOrigins }}
+{{- range (.Values.fides.configuration.additionalCORSOrigins | compact) }}
   {{- $cors = . | quote | append $cors }}
 {{- end }}
+{{ $cors = $cors | uniq }}
 {{ printf "[%s]" (join "," $cors) }}
 {{- end }}
 

--- a/fides/templates/fides/fides-config.yaml
+++ b/fides/templates/fides/fides-config.yaml
@@ -12,9 +12,7 @@ data:
     db_index = 0
     
     [security]
-    {{- if .Values.ingress.enabled }}
-    cors_origins = [{{ printf "https://%s" .Values.privacyCenter.publicHostname | quote }}, {{ printf "https://%s" .Values.fides.publicHostname | quote }}]
-    {{- end }}
+    cors_origins = {{ include "fides.corsOrigins" . | trim }}
 
     [execution]
 

--- a/fides/templates/fides/fides-config.yaml
+++ b/fides/templates/fides/fides-config.yaml
@@ -13,7 +13,7 @@ data:
     
     [security]
     {{- if .Values.ingress.enabled }}
-    cors_origins = [{{ printf "https://%s" .Values.ingress.hosts.privacyCenter | quote }}, {{ printf "https://%s" .Values.ingress.hosts.fides | quote }}]
+    cors_origins = [{{ printf "https://%s" .Values.privacyCenter.publicHostname | quote }}, {{ printf "https://%s" .Values.fides.publicHostname | quote }}]
     {{- end }}
 
     [execution]

--- a/fides/templates/ingress.yaml
+++ b/fides/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: {{ .Values.ingress.hosts.fides | quote }}
+    - host: {{ .Values.fides.publicHostname | quote }}
       http:
           paths:
           - path: /
@@ -50,7 +50,7 @@ spec:
               serviceName: {{ include "fides.fullname" . }}
               servicePort: {{ .Values.fides.service.port }}
               {{- end }}
-    - host: {{ .Values.ingress.hosts.privacyCenter | quote }}
+    - host: {{ .Values.privacyCenter.publicHostname | quote }}
       http:
           paths:
           - path: /

--- a/fides/templates/privacy-center/config.yaml
+++ b/fides/templates/privacy-center/config.yaml
@@ -8,5 +8,5 @@ data:
   # For config.json, parse the base configuration and replace the server URL with the actual Fides URL.
   config.json: |
 {{- $config := .Files.Get (default "config/privacyCenterConfig.json" .Values.privacyCenter.configuration.configJsonPath) | fromJson }}
-{{- $_ := set $config "server_url_production" ( printf "https://%s/api/v1" .Values.ingress.hosts.fides ) }}
+{{- $_ := set $config "server_url_production" ( printf "https://%s/api/v1" .Values.fides.publicHostname ) }}
 {{- $config  | toJson | toString | nindent 4 }}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -35,6 +35,8 @@ fides:
     # fides.configuration.fidesSecuritySecretName is an optional parameter that respresents the name of a Kubernetes secret containing sensitive Fides configuration elements. This secret must have the following keys: 
     # FIDES__SECURITY__APP_ENCRYPTION_KEY, FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID, FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET, FIDES__SECURITY__DRP_JWT_SECRET
     fidesSecuritySecretName: ""
+    # fides.configuration.additionalCORSOrigins is an optional parameter to configure allowed CORS origins in addition to the Fides and Privacy Center URLs.
+    additionalCORSOrigins: []
   # fides.publicHostname is used to set the allowed CORS origins for Fides, e.g. fides.example.com
   publicHostname: ""
   fullnameOverride: ""

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -35,6 +35,8 @@ fides:
     # fides.configuration.fidesSecuritySecretName is an optional parameter that respresents the name of a Kubernetes secret containing sensitive Fides configuration elements. This secret must have the following keys: 
     # FIDES__SECURITY__APP_ENCRYPTION_KEY, FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID, FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET, FIDES__SECURITY__DRP_JWT_SECRET
     fidesSecuritySecretName: ""
+  # fides.publicHostname is used to set the allowed CORS origins for Fides, e.g. fides.example.com
+  publicHostname: ""
   fullnameOverride: ""
   service:
     type: NodePort
@@ -63,6 +65,8 @@ privacyCenter:
     # privacyCenter.configuration.configCSSPath specifies the location of the config.css file to override the default styles.
     configCSSPath: config/privacyCenterConfig.css
   nameOverride: ""
+  # privacyCenter.publicHostname is used to set the allowed CORS origins for Fides, e.g. privacy.example.com
+  publicHostname: ""
   fullnameOverride: ""
   service:
     type: NodePort
@@ -99,9 +103,6 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    fides: "" # fides.example.com
-    privacyCenter: "" # privacy.example.com
   tls: []
   #  - secretName: fides-tls
   #    hosts:


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

Hosts are now configured under the keys `.Values.fides.publicHostname` and `.Values.privacyCenter.publicHostname` to account for cases where an ingress is not being used. 

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Relevant Follow-Up Issues Created
