### PR TITLE
feat: make deployment strategy configurable

### DIFF
--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.4.1
+version: 0.4.2
 appVersion: "2.5.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/templates/_helpers.tpl
+++ b/fides/templates/_helpers.tpl
@@ -114,6 +114,18 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Control the deployment strategy
+*/}}
+{{- define "fides.deploymentStrategy" -}}
+type: {{ ternary "RollingUpdate" "Recreate" .Values.useRollingUpdate}}
+{{- if .Values.useRollingUpdate }}
+rollingUpdate:
+  maxSurge: 1
+  maxUnavailable: 0
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the secret to store FIDES__SECURITY environment variables
 */}}
 {{- define "fides.fidesSecuritySecretName" -}}

--- a/fides/templates/fides/fides-deployment.yaml
+++ b/fides/templates/fides/fides-deployment.yaml
@@ -11,10 +11,7 @@ spec:
     matchLabels:
       {{- include "fides.fides.selectorLabels" . | nindent 6 }}
   strategy: 
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    {{- include "fides.deploymentStrategy" . | nindent 4 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/fides/templates/privacy-center/deployment.yaml
+++ b/fides/templates/privacy-center/deployment.yaml
@@ -11,10 +11,7 @@ spec:
     matchLabels:
       {{- include "fides.privacyCenter.selectorLabels" . | nindent 6 }}
   strategy: 
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    {{- include "fides.deploymentStrategy" . | nindent 4 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -77,6 +77,11 @@ privacyCenter:
 nameOverride: ""
 imagePullSecrets: []
 
+# useRollingUpdate helps to minimize upgrade downtime by running deployment upgrades with a RollingUpdate strategy.
+# When useRollingUpdate is set to false, the Recreate strategy is used instead. For production deployments, 
+# useRollingUpdate should be set to true.
+useRollingUpdate: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

Adds a new values.yaml entry `useRollingUpdate` to determine whether to gracefully roll the pods or whether to terminate and then recreate the pods. 

`useRollingUpdate == true` -> configure the deployment strategies to run rolling updates (graceful, for prod)
`useRollingUpdate == false` -> configure the deployment strategies to replace the existing pods (not graceful for dev)

<!--- list your code changes here along with any caveats and notes --->

* Change made to fides deployment and the privacy center deployments.

This was tested with positive results.

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
