### PR TITLE
feat: allow Helm to also deploy and configure Redis

### DIFF
--- a/fides/Chart.lock
+++ b/fides/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 17.6.0
+digest: sha256:84d1208e5e7c8a9234847b3ac41808b5ed99ed20f2bdb4e495d0ddb0ba779ccd
+generated: "2023-01-31T11:55:16.912566-06:00"

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.5.0
+version: 0.6.0
 appVersion: "2.5.1"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application
@@ -15,3 +15,8 @@ icon: https://raw.githubusercontent.com/ethyca/fides/main/docs/fides/docs/img/fi
 home: https://fid.es
 sources:
   - https://github.com/ethyca/fides
+dependencies:
+- name: redis
+  version: "17.6.0"
+  repository: "https://charts.bitnami.com/bitnami"
+  condition: redis.deployRedis

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -9,10 +9,12 @@ fides:
     tag: ""
   configuration:
     # fides.configuration.dbSecretName is the name of the Kubernetes secret containing the Postgres connection information
-    # This secret should have at least the following keys: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE
+    # This secret should have at least the following keys: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE. This value
+    # is required.
     dbSecretName: ""
     # fides.configuration.redisSecretName is the name of the Kubernetes secret containing the Redis connection information
-    # This secret should have at least the following keys: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD
+    # This secret should have at least the following keys: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD. This value is required if
+    # the value of redis.deployRedis is false.
     redisSecretName: ""
     # fides.configure.additionalEnvVar adds arbitrary environment variables to the configuration, in addition to those set
     # by the Helm chart. See https://ethyca.github.io/fides/installation/configuration/ for all possible values.
@@ -28,7 +30,7 @@ fides:
       - name: FIDES__USER__ANALYTICS_OPT_OUT
         value: "true"
       - name: FIDES__REDIS__SSL
-        value: "true"
+        value: "false"
       - name: FIDES__REDIS__SSL_CERT_REQS # Accepted values include: none, optional and require.
         value: "none"
       # Additional environment variables may be declared here.
@@ -73,6 +75,10 @@ privacyCenter:
   service:
     type: NodePort
     port: 3000
+
+redis:
+  # redis.deployRedis configures whether to install and configure the Bitnami Redis Helm chart
+  deployRedis: false
 
 nameOverride: ""
 imagePullSecrets: []


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

This PR introduces the ability to conditionally deploy the Redis prerequisite as part of the Helm Chart. It uses the `bitnami/redis` chart as a dependency.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Increment Applicable Chart Versions
* [ ] Relevant Follow-Up Issues Created
