### PR TITLE
fix: run helm add repo for Bitnami

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -25,6 +25,10 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: 'v3.10.0'
+      - name: Configure Helm
+        id: helm-configure
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Run chart-releaser
         id: release-chart
         uses: helm/chart-releaser-action@v1.4.1


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

The last run of the CD pipeline (see #19) failed because it didn't have the Bitnami repo added to Helm. This PR fixes that.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Increment Applicable Chart Versions
* [ ] Relevant Follow-Up Issues Created
