### PR TITLE
Allow S3 bucket to be created as part of the Helm Chart and Allow Additional Env Vars via Secrets

### DIFF
--- a/fides/Chart.lock
+++ b/fides/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 17.7.2
 digest: sha256:4f4f92dbd957bc5a2394e49548a5733650b1b36d2ad47150a7f39e184f7ea27f
-generated: "2023-02-07T12:45:29.005938-06:00"
+generated: "2023-02-14T09:01:54.275474-06:00"

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.8.2
+version: 0.9.0
 appVersion: "2.6.5"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/README.md
+++ b/fides/README.md
@@ -40,6 +40,12 @@ To install this chart, you can clone this repository and run the following comma
 helm install fides ethyca/fides --values values.local.yaml
 ```
 
+## Manage S3 Bucket (optional)
+
+If you would also like to manage the S3 bucket to be used as a Fides storage destination, you must first install the appropriate AWS Controllers for Kubernetes [ACK](https://aws-controllers-k8s.github.io/community/docs/community/overview/) services. ACK is a way to manage AWS resources from within Kubernetes using Custom Resource Definitions. To get started, follow the (official ACK setup documentation)[https://aws-controllers-k8s.github.io/community/docs/user-docs/install/] for **S3**. 
+
+Additionally, [IAM Roles for Service Accounts](https://aws-controllers-k8s.github.io/community/docs/user-docs/irsa/) must be enabled.
+
 ## Additional information
 
 * Need some additional help with Fides? Try out our [Sample Fides Project](https://ethyca.github.io/fides/getting-started/sample_project/)!

--- a/fides/templates/fides/fides-deployment.yaml
+++ b/fides/templates/fides/fides-deployment.yaml
@@ -41,6 +41,10 @@ spec:
           envFrom:
             - secretRef: 
                 name: {{ include "fides.fidesSecuritySecretName" . }}
+            {{- if .Values.fides.configuration.additionalEnvVarsSecret }}
+            - secretRef: 
+                name: {{ .Values.fides.configuration.additionalEnvVarsSecret }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -46,6 +46,10 @@ spec:
           envFrom:
             - secretRef: 
                 name: {{ include "fides.fidesSecuritySecretName" . }}
+            {{- if .Values.fides.configuration.additionalEnvVarsSecret }}
+            - secretRef: 
+                name: {{ .Values.fides.configuration.additionalEnvVarsSecret }}
+            {{- end }}
           livenessProbe:
             exec:
               command: [

--- a/fides/templates/s3/s3-bucket.yaml
+++ b/fides/templates/s3/s3-bucket.yaml
@@ -1,0 +1,32 @@
+{{- if .Capabilities.APIVersions.Has "s3.services.k8s.aws/v1alpha1" -}}
+{{- with .Values.s3 -}}
+{{- if .createS3Bucket -}}
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: {{ .bucketName }}
+spec:
+  name: {{ .bucketName | required "bucketName must be provided when createS3Bucket is enabled."}}
+  acl: private
+  createBucketConfiguration:
+    {{- if (ne .region "us-east-1") }}
+    locationConstraint: {{ .region }}
+    {{- end }}
+  lifecycle: 
+    rules:
+      - status: Enabled
+        abortIncompleteMultipartUpload: 
+          daysAfterInitiation: 30
+        expiration: 
+          days: 30
+        filter: {}
+  publicAccessBlock: 
+    blockPublicACLs: true
+    blockPublicPolicy: true
+    ignorePublicACLs: true
+    restrictPublicBuckets: true
+{{- end -}}
+{{- else -}}
+{{- fail "ACK must be installed to manage S3 buckets. For more information, see README.md." -}}
+{{- end -}}
+{{- end -}}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -84,6 +84,15 @@ redis:
   # redis.deployRedis configures whether to install and configure the Bitnami Redis Helm chart
   deployRedis: false
 
+s3:
+  # s3.createS3Bucket creates an S3 bucket to be used as a Fides storage destination.
+  # In order to create S3 buckets, the S3 ACK must be installed. For more information see the chart's README.
+  createS3Bucket: false
+  # s3.bucketName represents the name of the bucket to create if s3.createS3Bucket is set to true.
+  bucketName: ""
+  # s3.region sets the location constraint and may be set to any valid AWS region.
+  region: us-east-1
+
 nameOverride: ""
 imagePullSecrets: []
 

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -34,6 +34,8 @@ fides:
       - name: FIDES__REDIS__SSL_CERT_REQS # Accepted values include: none, optional and require.
         value: "none"
       # Additional environment variables may be declared here.
+    # fides.configuration.additioanlEnvVarsSecret is an optional parameter representing the name of an existing secret containing environment variables to pass into the Fides containers.
+    additionalEnvVarsSecret: ""
     # fides.configuration.fidesSecuritySecretName is an optional parameter that respresents the name of a Kubernetes secret containing sensitive Fides configuration elements. This secret must have the following keys:
     # FIDES__SECURITY__APP_ENCRYPTION_KEY, FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID, FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET, FIDES__SECURITY__DRP_JWT_SECRET
     fidesSecuritySecretName: ""


### PR DESCRIPTION
I tried to also install ACK as part of this chart, but it ran into the issues found in this SO question: https://stackoverflow.com/questions/60283240/helm-chart-how-do-i-install-dependencies-first.

<!--- Please fill out this template in its entirety. --->
### Description of Changes

* Optionally create S3 bucket
* Updated instructions to install ACK.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
