### PR TITLE
Configurable Timeouts

### DIFF
--- a/fides/Chart.lock
+++ b/fides/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 12.1.14
+  version: 12.2.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.7.2
-digest: sha256:4f4f92dbd957bc5a2394e49548a5733650b1b36d2ad47150a7f39e184f7ea27f
-generated: "2023-02-14T09:01:54.275474-06:00"
+  version: 17.8.2
+digest: sha256:61201b0e19fc6b13309aece999e2d1c9bc16fcc5f839763b827a1e7401b48cf1
+generated: "2023-03-06T10:58:17.260155-06:00"

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.9.2
+version: 0.9.3
 appVersion: "2.7.1"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application
@@ -17,10 +17,10 @@ sources:
   - https://github.com/ethyca/fides
 dependencies:
   - name: postgresql
-    version: "12.1.14"
+    version: "12.2.2"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.deployPostgres
   - name: redis
-    version: "17.7.2"
+    version: "17.8.2"
     repository: "https://charts.bitnami.com/bitnami"
     condition: redis.deployRedis

--- a/fides/templates/fides/fides-deployment.yaml
+++ b/fides/templates/fides/fides-deployment.yaml
@@ -55,14 +55,14 @@ spec:
               port: http
             initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
             periodSeconds: 15
-            timeoutSeconds: 5
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
           readinessProbe:
             httpGet:
               path: /health
               port: http
             initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
           volumeMounts:
           - name: {{ $volume }}
             mountPath: {{ $configPath }}

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -59,7 +59,7 @@ spec:
               ]
             initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
             periodSeconds: 60
-            timeoutSeconds: 10
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
           volumeMounts:
           - name: {{ $volume }}
             mountPath: {{ $configPath }}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -50,6 +50,8 @@ fides:
   # fides.startupTimeSeconds configures the delay before liveness and readiness probes begin.
   # For local kubernetes clusters, such as minikube & kind, you may need to increase this value to 60 seconds.
   startupTimeSeconds: 30
+  # fides.healthCheckTimeoutSeconds configures the timeoutSeconds of the liveness and readiness probes.
+  healthCheckTimeoutSeconds: 5
   workers:
     # fides.workers.count determines how many workers the deployment will use to process DSRs.
     # To disable workers, set count to 0. This should be set to at least 1 in production environments.


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

This PR allows users to specify a probe timeout (defaults to 5 seconds) to accommodate different needs.
Additionally, it updates the dependencies of postgres and redis.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
