### PR TITLE
Customize Privacy Center via an existing configmap

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -31,7 +31,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Run chart-releaser
         id: release-chart
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.5.0
         with:
           charts_dir: "."
         env:

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.9.5
+version: 0.9.6
 appVersion: "2.8.1"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/templates/privacy-center/config.yaml
+++ b/fides/templates/privacy-center/config.yaml
@@ -1,3 +1,4 @@
+{{- if (empty .Values.privacyCenter.configuration.configFilesOverrideConfigMap) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,3 +11,4 @@ data:
 {{- $config := .Files.Get (default "config/privacyCenterConfig.json" .Values.privacyCenter.configuration.configJsonPath) | fromJson }}
 {{- $_ := set $config "server_url_production" ( printf "https://%s/api/v1" .Values.fides.publicHostname ) }}
 {{- $config  | toJson | toString | nindent 4 }}
+{{- end -}}

--- a/fides/templates/privacy-center/deployment.yaml
+++ b/fides/templates/privacy-center/deployment.yaml
@@ -56,7 +56,7 @@ spec:
       volumes:
         - name: {{ $volume }}
           configMap:
-            name: {{ include "fides.privacyCenter.fullname" . }}
+            name: {{(empty .Values.privacyCenter.configuration.configFilesOverrideConfigMap) | ternary (include "fides.privacyCenter.fullname" .) .Values.privacyCenter.configuration.configFilesOverrideConfigMap }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -72,6 +72,8 @@ privacyCenter:
     configJsonPath: config/privacyCenterConfig.json
     # privacyCenter.configuration.configCSSPath specifies the location of the config.css file to override the default styles.
     configCSSPath: config/privacyCenterConfig.css
+    # privacyCenter.configuration.configFilesOverride specifies the name of an existing configmap with the keys config.css and config.json containing the customization files.
+    configFilesOverrideConfigMap: ""
   nameOverride: ""
   # privacyCenter.publicHostname is used to set the allowed CORS origins for Fides, e.g. privacy.example.com
   publicHostname: ""


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

This PR introduces the ability to pass a configmap with the keys config.css and config.json to mount to the privacy center for customizations.


<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Increment Applicable Chart Versions
* [ ] Relevant Follow-Up Issues Created
