### PR TITLE
Create a New Helm Chart without Advanced Features such as `lookup`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,9 @@
 helm/fides:
   - "fides/**/*"
 
+helm/fides-minimal:
+  - "fides-minimal/**/*"
+
 documentation:
   - "**/*.md"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,11 @@ jobs:
         working-directory: ./fides/
         id: helm-dependency
         run: helm dependency build
+      - name: Lint Helm - Fides-minimal
+        working-directory: ./fides-minimal/
+        id: helm-lint-minimal
+        run: helm lint
+      - name: Fides - Check Helm Dependencies
+        working-directory: ./fides-minimal/
+        id: helm-dependency-minimal
+        run: helm dependency build

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -15,19 +15,31 @@ jobs:
       - name: Checkout
         id: checkout-code
         uses: actions/checkout@v3
-      - name: Get Current Chart Version
+      - name: Fides - Get Current Chart Version
         id: get-chart-version
         working-directory: ./fides/
         run: |
           echo CHART_VERSION_CURRENT=$(yq '.version' Chart.yaml) >> $GITHUB_OUTPUT
           echo FIDES_VERSION_CURRENT=$(yq '.appVersion' Chart.yaml) >> $GITHUB_OUTPUT
           echo NEW_VERSION_FOR_CHANGELOG=$(sed 's/\.//g' <<< ${{ github.event.client_payload.tag }}) >> $GITHUB_OUTPUT
-      - name: Increase Chart Patch Version
+      - name: Fides-minimal - Get Current Chart Version
+        id: fides-minimal-get-chart-version
+        working-directory: ./fides-minimal/
+        run: |
+          echo CHART_VERSION_CURRENT=$(yq '.version' Chart.yaml) >> $GITHUB_OUTPUT
+          echo FIDES_VERSION_CURRENT=$(yq '.appVersion' Chart.yaml) >> $GITHUB_OUTPUT
+          echo NEW_VERSION_FOR_CHANGELOG=$(sed 's/\.//g' <<< ${{ github.event.client_payload.tag }}) >> $GITHUB_OUTPUT
+      - name: Fides - Increase Chart Patch Version
         id: chart-semver
         uses: "WyriHaximus/github-action-next-semvers@v1"
         with:
           version: ${{ steps.get-chart-version.outputs.CHART_VERSION_CURRENT }}
-      - name: Update Fides Version
+      - name: Fides-minimal - Increase Chart Patch Version
+        id: fides-minimal-chart-semver
+        uses: "WyriHaximus/github-action-next-semvers@v1"
+        with:
+          version: ${{ steps.fides-minimal-get-chart-version.outputs.CHART_VERSION_CURRENT }}
+      - name: Fides - Update Fides Version
         id: update-chart
         working-directory: ./fides/
         run: |
@@ -35,6 +47,15 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           yq '.appVersion = "${{ github.event.client_payload.tag }}"' Chart.yaml --inplace
           yq '.version = "${{ steps.chart-semver.outputs.patch }}"' Chart.yaml --inplace
+          echo BRANCH=version-fides-${{ github.event.client_payload.tag }} >> $GITHUB_OUTPUT
+      - name: Fides-minimal - Update Fides Version
+        id: fides-minimal-update-chart
+        working-directory: ./fides-minimal/
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          yq '.appVersion = "${{ github.event.client_payload.tag }}"' Chart.yaml --inplace
+          yq '.version = "${{ steps.fides-minimal-chart-semver.outputs.patch }}"' Chart.yaml --inplace
           echo BRANCH=version-fides-${{ github.event.client_payload.tag }} >> $GITHUB_OUTPUT
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
@@ -44,14 +65,19 @@ jobs:
           body: |
             # Fides Version Upgrade
 
-            * Upgrade Fides version from [`${{ steps.get-chart-version.outputs.FIDES_VERSION_CURRENT }}`](https://github.com/ethyca/fides/releases/tag/${{ steps.get-chart-version.outputs.FIDES_VERSION_CURRENT }}) to [`${{ github.event.client_payload.tag }}`](https://github.com/ethyca/fides/releases/tag/${{ github.event.client_payload.tag }})
-            * Increment Chart version from `${{ steps.get-chart-version.outputs.CHART_VERSION_CURRENT }}` to `${{ steps.chart-semver.outputs.patch }}`
+            * **Fides Chart** 
+              * Upgrade Fides version from [`${{ steps.get-chart-version.outputs.FIDES_VERSION_CURRENT }}`](https://github.com/ethyca/fides/releases/tag/${{ steps.get-chart-version.outputs.FIDES_VERSION_CURRENT }}) to [`${{ github.event.client_payload.tag }}`](https://github.com/ethyca/fides/releases/tag/${{ github.event.client_payload.tag }})
+              * Increment Chart version from `${{ steps.get-chart-version.outputs.CHART_VERSION_CURRENT }}` to `${{ steps.chart-semver.outputs.patch }}`
+            * **Fides-minimal Chart**
+              * Upgrade Fides version from [`${{ steps.fides-minimal-get-chart-version.outputs.FIDES_VERSION_CURRENT }}`](https://github.com/ethyca/fides/releases/tag/${{ steps.fides-minimal-get-chart-version.outputs.FIDES_VERSION_CURRENT }}) to [`${{ github.event.client_payload.tag }}`](https://github.com/ethyca/fides/releases/tag/${{ github.event.client_payload.tag }})
+              * Increment Chart version from `${{ steps.fides-minimal-get-chart-version.outputs.CHART_VERSION_CURRENT }}` to `${{ steps.fides-minimal-chart-semver.outputs.patch }}`
 
             ## Pre-merge Checklist
 
             - [ ] - Confirm that ${{ github.event.client_payload.tag }} is a valid version of Fides and is published to [Docker Hub](https://hub.docker.com/r/ethyca/fides/tags?page=1&name=${{ github.event.client_payload.tag }})
             - [ ] - Review [Changelog](https://github.com/ethyca/fides/blob/main/CHANGELOG.md#${{ steps.get-chart-version.outputs.NEW_VERSION_FOR_CHANGELOG }})
-            - [ ] - Confirm that ${{ steps.chart-semver.outputs.patch }} is the appropriate SemVer value for the new version of the chart
+            - [ ] - Confirm that ${{ steps.chart-semver.outputs.patch }} is the appropriate SemVer value for the new version of the **Fides** chart
+            - [ ] - Confirm that ${{ steps.fides-minimal-chart-semver.outputs.patch }} is the appropriate SemVer value for the new version of the **Fides-minimal** chart
             - [ ] - Test new chart for regressions - `git fetch origin ${{ steps.update-chart.outputs.BRANCH }} && git switch -c ${{ steps.update-chart.outputs.BRANCH }} origin/${{ steps.update-chart.outputs.BRANCH }}`
           labels: chore
           branch: ${{ steps.update-chart.outputs.BRANCH }}

--- a/fides-minimal/.helmignore
+++ b/fides-minimal/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/fides-minimal/Chart.yaml
+++ b/fides-minimal/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: fides-minimal
+version: 0.11.1
+appVersion: "2.13.0"
+description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code. This version of the Helm chart removes some excess features such as the lookup function which may not be available in all cases, such as ArgoCD.
+type: application
+keywords:
+  - fides
+  - fidesctl
+  - fidesops
+  - privacy
+  - gdpr
+  - ccpa
+icon: https://raw.githubusercontent.com/ethyca/fides/main/docs/fides/docs/img/fides-logo.svg
+home: https://fid.es
+sources:
+  - https://github.com/ethyca/fides
+

--- a/fides-minimal/LICENSE
+++ b/fides-minimal/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/fides-minimal/README.md
+++ b/fides-minimal/README.md
@@ -43,7 +43,7 @@ helm pull ethyca/fides-minimal
 
 To install this chart, create a local values file to override the defaults and run the following command:
 ```sh
-helm install fides ethyca/fides --values values.local.yaml
+helm install fides ethyca/fides-minimal --values values.local.yaml
 ```
 
 ## Additional information

--- a/fides-minimal/README.md
+++ b/fides-minimal/README.md
@@ -14,7 +14,7 @@ Before deploying the Helm chart, you will need the several dependencies, dependi
   * A PostgreSQL database
   * A Kubernetes secret for the Postgres containing at least the following keys:
     * `DB_HOST`
-    * `DB_PORT` - \[Optional - Defaults to `5432`\]
+    * `DB_PORT`
     * `DB_DATABASE`
     * `DB_USERNAME`
     * `DB_PASSWORD`
@@ -22,8 +22,14 @@ Before deploying the Helm chart, you will need the several dependencies, dependi
   * A Redis cache
   * A Kubernetes secret for the Redis containing at least the following keys:
     * `REDIS_HOST`
-    * `REDIS_PORT` - \[Optional - Defaults to `6379`\]
+    * `REDIS_PORT`
     * `REDIS_PASSWORD`
+* Fides
+  * A Kubernetes secret for Fides containing at least the following keys:
+    * `FIDES__SECURITY__APP_ENCRYPTION_KEY`
+    * `FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID`
+    * `FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET`
+    * `FIDES__SECURITY__DRP_JWT_SECRET`
 
 ## Configuration
 

--- a/fides-minimal/README.md
+++ b/fides-minimal/README.md
@@ -10,7 +10,6 @@ Before deploying the Helm chart, you will need the several dependencies, dependi
 * [Helm v3](https://helm.sh/docs/intro/install/) installed on your machine
 * A Kubernetes cluster to which Fides will be deployed
 
-### Optional Prerequisites
 * Postgres
   * A PostgreSQL database
   * A Kubernetes secret for the Postgres containing at least the following keys:
@@ -39,19 +38,13 @@ Most of the Fides configuration is handled natively within the chart; however, y
 To download the chart, run the following commands: 
 ```sh
 helm repo add ethyca https://helm.ethyca.com
-helm pull ethyca/fides
+helm pull ethyca/fides-minimal
 ```
 
 To install this chart, create a local values file to override the defaults and run the following command:
 ```sh
 helm install fides ethyca/fides --values values.local.yaml
 ```
-
-## Manage S3 Bucket (optional)
-
-If you would also like to manage the S3 bucket to be used as a Fides storage destination, you must first install the appropriate AWS Controllers for Kubernetes [ACK](https://aws-controllers-k8s.github.io/community/docs/community/overview/) services. ACK is a way to manage AWS resources from within Kubernetes using Custom Resource Definitions. To get started, follow the [official ACK setup documentation](https://aws-controllers-k8s.github.io/community/docs/user-docs/install/) for **S3**. 
-
-Additionally, [IAM Roles for Service Accounts](https://aws-controllers-k8s.github.io/community/docs/user-docs/irsa/) must be enabled.
 
 ## Additional information
 

--- a/fides-minimal/README.md
+++ b/fides-minimal/README.md
@@ -1,0 +1,59 @@
+# Fides-minimal Helm Chart
+
+This [Helm](https://helm.sh) chart deploys [Fides](https://fid.es/docs), an open-source privacy engineering platform. Unlike the [Fides Helm chart](../fides/), the Fides-minimal Helm chart has fewer bells-and-whistles, for more advanced use cases and control. In most circumstances, you should use the generic Fides chart. If you use ArgoCD, try out this chart, which does not use the `lookup` function. 
+
+This chart does not generate secrets, so all of them must be generated outside of Helm and referenced in the `values.yaml`. Additionally, this chart does not deploy the auxiliary services, such as Postgres and Redis.
+
+## Prerequisites
+Before deploying the Helm chart, you will need the several dependencies, depending on your `values.yaml` configuration.
+
+* [Helm v3](https://helm.sh/docs/intro/install/) installed on your machine
+* A Kubernetes cluster to which Fides will be deployed
+
+### Optional Prerequisites
+* Postgres
+  * A PostgreSQL database
+  * A Kubernetes secret for the Postgres containing at least the following keys:
+    * `DB_HOST`
+    * `DB_PORT` - \[Optional - Defaults to `5432`\]
+    * `DB_DATABASE`
+    * `DB_USERNAME`
+    * `DB_PASSWORD`
+* Redis
+  * A Redis cache
+  * A Kubernetes secret for the Redis containing at least the following keys:
+    * `REDIS_HOST`
+    * `REDIS_PORT` - \[Optional - Defaults to `6379`\]
+    * `REDIS_PASSWORD`
+
+## Configuration
+
+See [values.yaml](./values.yaml) for the configuration options.
+
+You'll likely want to override some of the values set in the `values.yaml` file. To do so, create a local version of the file with your configuration.
+
+Most of the Fides configuration is handled natively within the chart; however, you may pass additional environment variables to Fides by setting `fides.configuration.additionalEnvVars` or `fides.configuration.additionalEnvVarsSecret`. See the [Fides configuration guide](https://docs.ethyca.com/fides/get_started/configuration) for all possible values.
+
+## Chart installation
+
+To download the chart, run the following commands: 
+```sh
+helm repo add ethyca https://helm.ethyca.com
+helm pull ethyca/fides
+```
+
+To install this chart, create a local values file to override the defaults and run the following command:
+```sh
+helm install fides ethyca/fides --values values.local.yaml
+```
+
+## Manage S3 Bucket (optional)
+
+If you would also like to manage the S3 bucket to be used as a Fides storage destination, you must first install the appropriate AWS Controllers for Kubernetes [ACK](https://aws-controllers-k8s.github.io/community/docs/community/overview/) services. ACK is a way to manage AWS resources from within Kubernetes using Custom Resource Definitions. To get started, follow the [official ACK setup documentation](https://aws-controllers-k8s.github.io/community/docs/user-docs/install/) for **S3**. 
+
+Additionally, [IAM Roles for Service Accounts](https://aws-controllers-k8s.github.io/community/docs/user-docs/irsa/) must be enabled.
+
+## Additional information
+
+* Need some additional help with Fides? Try out our [Sample Fides Project](https://docs.ethyca.com/fides/get_started/quickstart)!
+* Not familiar with Helm? Take a look at [Helm's quick start guide](https://helm.sh/docs/intro/quickstart/)!

--- a/fides-minimal/config/privacyCenterConfig.css
+++ b/fides-minimal/config/privacyCenterConfig.css
@@ -1,0 +1,1 @@
+/* Global CSS overrides */

--- a/fides-minimal/config/privacyCenterConfig.json
+++ b/fides-minimal/config/privacyCenterConfig.json
@@ -1,0 +1,67 @@
+{
+  "title": "Privacy Center",
+  "description": "When you use our services, you're trusting us with your information. We understand this is a big responsibility and work hard to protect your information and put you in control.",
+  "server_url_development": "",
+  "server_url_production": "",
+  "logo_path": "/logo.svg",
+  "actions": [
+    {
+      "policy_key": "default_access_policy",
+      "icon_path": "/download.svg",
+      "title": "Access your data",
+      "description": "We will provide you a report of all your personal data.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
+    },
+    {
+      "policy_key": "default_erasure_policy",
+      "icon_path": "/delete.svg",
+      "title": "Erase your data",
+      "description": "We will erase all of your personal data. This action cannot be undone.",
+      "identity_inputs": {
+        "name": "optional",
+        "email": "required",
+        "phone": "optional"
+      }
+    }
+  ],
+  "includeConsent": true,
+  "consent": {
+    "icon_path": "/consent.svg",
+    "title": "Manage your consent",
+    "description": "Manage your consent preferences, including the option to select 'Do Not Sell My Personal Information'.",
+    "cookieName": "fidesConsent",
+    "consentOptions": [
+      {
+        "fidesDataUseKey": "advertising",
+        "name": "Data Sales or Sharing",
+        "description": "We may use some of your personal information for behavioral advertising purposes, which may be interpreted as 'Data Sales' or 'Data Sharing' under regulations such as CCPA, CPRA, VCDPA, etc.",
+        "url": "https://example.com/privacy#data-sales",
+        "default": true,
+        "highlight": false,
+        "cookieKeys": ["data_sales"]
+      },
+      {
+        "fidesDataUseKey": "advertising.first_party",
+        "name": "Email Marketing",
+        "description": "We may use some of your personal information to contact you about our products & services.",
+        "url": "https://example.com/privacy#email-marketing",
+        "default": true,
+        "highlight": false,
+        "cookieKeys": []
+      },
+      {
+        "fidesDataUseKey": "improve",
+        "name": "Product Analytics",
+        "description": "We may use some of your personal information to collect analytics about how you use our products & services.",
+        "url": "https://example.com/privacy#analytics",
+        "default": true,
+        "highlight": false,
+        "cookieKeys": []
+      }
+    ]
+  }
+}

--- a/fides-minimal/templates/NOTES.txt
+++ b/fides-minimal/templates/NOTES.txt
@@ -1,0 +1,14 @@
+■ Fides
+Version: {{ include "fides.dockerTag" . }}
+{{ if .Values.ingress.enabled }}
+Fides Admin UI: https://{{.Values.fides.publicHostname}}
+{{- if .Values.privacyCenter.enabled }}
+Privacy Center: https://{{.Values.privacyCenter.publicHostname}}
+{{- end }}
+{{- end }}
+{{ if .Release.IsInstall }}
+For more information, check out the following resources:
+  - Documentation and guides https://fid.es/docs
+  - Configuration reference: https://fid.es/config
+  - Slack community: https://fid.es/slack
+{{- end }}

--- a/fides-minimal/templates/_helpers.tpl
+++ b/fides-minimal/templates/_helpers.tpl
@@ -1,0 +1,212 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "fides.name" -}}
+  {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for Fides
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fides.fullname" -}}
+  {{- $baseName := default .Chart.Name .Values.nameOverride }}
+    {{- if .Values.fides.fullnameOverride }}
+      {{- $baseName = .Values.fides.fullnameOverride }}
+    {{- else }}
+      {{- if contains $baseName .Release.Name }}
+        {{- $baseName = .Release.Name }}
+      {{- else }}
+        {{- printf "%s-%s" .Release.Name $baseName }}
+      {{- end }}
+    {{- end }}
+  {{- $baseName | trunc 63 | trimSuffix "-"}}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name for Fides Workers
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fides.worker.fullname" -}}
+  {{- printf "worker-%s" ( include "fides.fullname" . )  | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Create a default fully qualified app name for the Privacy Center
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "fides.privacyCenter.fullname" -}}
+  {{- printf "pc-%s" ( include "fides.fullname" . )  | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "fides.chart" -}}
+  {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+The Docker tag from which to pull the image.
+*/}}
+{{- define "fides.dockerTag" -}}
+{{ .Values.fides.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "fides.labels" -}}
+helm.sh/chart: {{ include "fides.chart" . }}
+{{ include "fides.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Base Selector labels
+*/}}
+{{- define "fides.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fides.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Fides Selector labels
+*/}}
+{{- define "fides.fides.selectorLabels" -}}
+{{ include "fides.selectorLabels" . }}
+app.kubernetes.io/component: "fides"
+{{- end }}
+
+{{/*
+Privacy Center Selector labels
+*/}}
+{{- define "fides.privacyCenter.selectorLabels" -}}
+{{ include "fides.selectorLabels" . }}
+app.kubernetes.io/component: "privacy-center"
+{{- end }}
+
+{{/*
+Fides Worker Selector labels
+*/}}
+{{- define "fides.worker.selectorLabels" -}}
+{{ include "fides.selectorLabels" . }}
+app.kubernetes.io/component: "fides-worker"
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "fides.serviceAccountName" -}}
+  {{- if .Values.serviceAccount.create }}
+    {{- default (include "fides.fullname" .) .Values.serviceAccount.name }}
+  {{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+  {{- end }}
+{{- end }}
+
+{{/*
+Control the deployment strategy
+*/}}
+{{- define "fides.deploymentStrategy" -}}
+type: {{ ternary "RollingUpdate" "Recreate" .Values.useRollingUpdate}}
+{{- if .Values.useRollingUpdate }}
+rollingUpdate:
+  maxSurge: 1
+  maxUnavailable: 0
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the secret to store FIDES__SECURITY environment variables
+*/}}
+{{- define "fides.fidesSecuritySecretName" -}}
+{{ default (printf "fides-security-%s" ( include "fides.fullname" . ) | trunc 63 | trimSuffix "-") .Values.fides.configuration.fidesSecuritySecretName }}
+{{- end }}
+
+{{/*
+Create the name of the config map to store the fides.toml file.
+*/}}
+{{- define "fides.tomlConfigMapName" -}}
+{{ printf "fides-toml-%s" ( include "fides.fullname" . ) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create the name of the config map to store the fides.toml file.
+*/}}
+{{- define "fides.worker.tomlConfigMapName" -}}
+{{ printf "worker-%s" (include "fides.tomlConfigMapName" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+List of CORS origins, concatenated, deduplicated, and formatted.
+*/}}
+{{- define "fides.corsOrigins" -}}
+{{ $cors := list (printf "https://%s" .Values.privacyCenter.publicHostname | quote ) (printf "https://%s" .Values.fides.publicHostname | quote) }}
+{{- range (.Values.fides.configuration.additionalCORSOrigins | compact) }}
+  {{- $cors = . | quote | append $cors }}
+{{- end }}
+{{ $cors = $cors | uniq }}
+{{ printf "[%s]" (join "," $cors) }}
+{{- end }}
+
+{{/*
+The set of environment variables for Fides and workers
+*/}}
+{{- define "fides.env" -}}
+{{- $namespace := .Release.Namespace }}
+{{- $releaseName := .Release.Name }}
+{{- $redisDeployment := .Values.redis }}
+{{- $pgDeployment := .Values.postgresql }}
+{{- with .Values.fides.configuration }}
+{{- .additionalEnvVars | toYaml }}
+- name: FIDES__DATABASE__SERVER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .dbSecretName }}
+      key: DB_HOST
+- name: FIDES__DATABASE__PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .dbSecretName }}
+      key: DB_PORT
+- name: FIDES__DATABASE__USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .dbSecretName }}
+      key: DB_USERNAME
+- name: FIDES__DATABASE__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .dbSecretName }}
+      key: DB_PASSWORD
+- name: FIDES__DATABASE__DB
+  valueFrom:
+    secretKeyRef:
+      name: {{ .dbSecretName }}
+      key: DB_DATABASE
+- name: FIDES__REDIS__HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ .redisSecretName }}
+      key: REDIS_HOST
+- name: FIDES__REDIS__PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .redisSecretName }}
+      key: REDIS_PORT
+- name: FIDES__REDIS__PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .redisSecretName }}
+      key: REDIS_PASSWORD
+{{- end }}
+{{- end }}

--- a/fides-minimal/templates/fides/fides-config.yaml
+++ b/fides-minimal/templates/fides/fides-config.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fides.tomlConfigMapName" . }}
+data:
+  fides.toml: |
+    [database]
+    enabled = true
+
+    [redis]
+    enabled = true
+    db_index = 0
+    
+    [celery]
+    event_queue_prefix = "fides_worker"
+    task_default_queue = "fides"
+    task_always_eager = {{ not $.worker }}
+
+    [security]
+    cors_origins = {{ include "fides.corsOrigins" . | trim }}
+
+    [execution]
+
+    [root_user]
+
+    [admin_ui]
+
+    [notifications]

--- a/fides-minimal/templates/fides/fides-deployment.yaml
+++ b/fides-minimal/templates/fides/fides-deployment.yaml
@@ -1,0 +1,86 @@
+{{- $volume := "config" }}
+{{- $configPath := "/etc/fides/config" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fides.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fides.fides.selectorLabels" . | nindent 6 }}
+  strategy: 
+    {{- include "fides.deploymentStrategy" . | nindent 4 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fides.fides.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fides.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fides
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ printf "%s:%s" .Values.fides.image.repository ( include "fides.dockerTag" .)}}
+          imagePullPolicy: {{ .Values.fides.image.pullPolicy }}
+          env:
+            - name: FIDES__CONFIG_PATH
+              value: {{ printf "%s/fides.toml" $configPath }}
+            {{- include "fides.env" . | nindent 12 }}
+          envFrom:
+            - secretRef: 
+                name: {{ include "fides.fidesSecuritySecretName" . }}
+            {{- if .Values.fides.configuration.additionalEnvVarsSecret }}
+            - secretRef: 
+                name: {{ .Values.fides.configuration.additionalEnvVarsSecret }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
+            periodSeconds: 15
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
+            periodSeconds: 10
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
+          volumeMounts:
+          - name: {{ $volume }}
+            mountPath: {{ $configPath }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: {{ $volume }}
+          configMap:
+            name: {{ include "fides.tomlConfigMapName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/fides-minimal/templates/fides/fides-service.yaml
+++ b/fides-minimal/templates/fides/fides-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fides.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.fides.service.type }}
+  ports:
+    - port: {{ .Values.fides.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fides.fides.selectorLabels" . | nindent 4 }}

--- a/fides-minimal/templates/fides/worker-config.yaml
+++ b/fides-minimal/templates/fides/worker-config.yaml
@@ -1,0 +1,31 @@
+{{- if $.worker }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fides.worker.tomlConfigMapName" . }}
+data:
+  fides.toml: |
+    [database]
+    enabled = true
+
+    [redis]
+    enabled = true
+    db_index = 0
+    
+    [celery]
+    event_queue_prefix = "fides_worker"
+    task_default_queue = "fides"
+    task_always_eager = true
+    redis_socket_keepalive = true
+
+    [security]
+    cors_origins = {{ include "fides.corsOrigins" . | trim }}
+
+    [execution]
+
+    [root_user]
+
+    [admin_ui]
+
+    [notifications]
+{{- end }}

--- a/fides-minimal/templates/fides/worker-deployment.yaml
+++ b/fides-minimal/templates/fides/worker-deployment.yaml
@@ -1,0 +1,84 @@
+{{- $_ := set $ "worker" ( ge (.Values.fides.workers.count | int) 1) }}
+{{- if $.worker }}
+{{- $volume := "config" }}
+{{- $configPath := "/etc/fides/config" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fides.worker.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.fides.workers.count | int }}
+  selector:
+    matchLabels:
+      {{- include "fides.worker.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- include "fides.deploymentStrategy" . | nindent 4 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fides.worker.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fides.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fides
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ printf "%s:%s" .Values.fides.image.repository ( include "fides.dockerTag" .)}}
+          imagePullPolicy: {{ .Values.fides.image.pullPolicy }}
+          command: ["fides"]
+          args: ["worker"]
+          env:
+            - name: FIDES__CONFIG_PATH
+              value: {{ printf "%s/fides.toml" $configPath }}
+            {{- include "fides.env" . | nindent 12 }}
+          envFrom:
+            - secretRef: 
+                name: {{ include "fides.fidesSecuritySecretName" . }}
+            {{- if .Values.fides.configuration.additionalEnvVarsSecret }}
+            - secretRef: 
+                name: {{ .Values.fides.configuration.additionalEnvVarsSecret }}
+            {{- end }}
+          livenessProbe:
+            exec:
+              command: [
+                "bash",
+                "-c",
+                "celery --quiet --no-color --app fides.api.ops.tasks inspect ping --destination celery@$HOSTNAME --json"
+              ]
+            initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
+            periodSeconds: 60
+            timeoutSeconds: {{ .Values.fides.healthCheckTimeoutSeconds | default 5 }}
+          volumeMounts:
+          - name: {{ $volume }}
+            mountPath: {{ $configPath }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: {{ $volume }}
+          configMap:
+            name: {{ include "fides.worker.tomlConfigMapName" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/fides-minimal/templates/ingress.yaml
+++ b/fides-minimal/templates/ingress.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ include "fides.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.fides.publicHostname | quote }}
+      http:
+          paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "fides.fullname" . }}
+                port:
+                  number: {{ .Values.fides.service.port }}
+              {{- else }}
+              serviceName: {{ include "fides.fullname" . }}
+              servicePort: {{ .Values.fides.service.port }}
+              {{- end }}
+    - host: {{ .Values.privacyCenter.publicHostname | quote }}
+      http:
+          paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ include "fides.privacyCenter.fullname" . }}
+                port:
+                  number: {{ .Values.privacyCenter.service.port }}
+              {{- else }}
+              serviceName: {{ include "fides.privacyCenter.fullname" . }}
+              servicePort: {{ .Values.privacyCenter.service.port }}
+              {{- end }}
+{{- end }}

--- a/fides-minimal/templates/privacy-center/config.yaml
+++ b/fides-minimal/templates/privacy-center/config.yaml
@@ -1,0 +1,14 @@
+{{- if (empty .Values.privacyCenter.configuration.configFilesOverrideConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fides.privacyCenter.fullname" . }}
+data:
+  config.css: |
+{{- .Files.Get (default "config/privacyCenterConfig.css" .Values.privacyCenter.configuration.configCSSPath) | nindent 4 }}
+  # For config.json, parse the base configuration and replace the server URL with the actual Fides URL.
+  config.json: |
+{{- $config := .Files.Get (default "config/privacyCenterConfig.json" .Values.privacyCenter.configuration.configJsonPath) | fromJson }}
+{{- $_ := set $config "server_url_production" ( printf "https://%s/api/v1" .Values.fides.publicHostname ) }}
+{{- $config  | toJson | toString | nindent 4 }}
+{{- end -}}

--- a/fides-minimal/templates/privacy-center/deployment.yaml
+++ b/fides-minimal/templates/privacy-center/deployment.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.privacyCenter.enabled }}
+{{- $volume := "config" }}
+{{- $configPath := "/app/config" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fides.privacyCenter.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "fides.privacyCenter.selectorLabels" . | nindent 6 }}
+  strategy: 
+    {{- include "fides.deploymentStrategy" . | nindent 4 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "fides.privacyCenter.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fides.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: privacy-center
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.privacyCenter.image.repository }}:{{ .Values.privacyCenter.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.privacyCenter.image.pullPolicy }}
+          env:
+            - name: FIDES_PRIVACY_CENTER__FIDES_API_URL
+              value: {{ printf "https://%s/api/v1" .Values.fides.publicHostname }}
+            - name: FIDES_PRIVACY_CENTER__CONFIG_JSON_URL
+              value: {{ printf "file://%s/config.json" $configPath }}
+            - name: FIDES_PRIVACY_CENTER__CONFIG_CSS_URL
+              value: {{ printf "file://%s/config.css" $configPath }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            failureThreshold: 24
+            periodSeconds: 5
+          volumeMounts:
+          - name: {{ $volume }}
+            mountPath: /app/config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: {{ $volume }}
+          configMap:
+            name: {{(empty .Values.privacyCenter.configuration.configFilesOverrideConfigMap) | ternary (include "fides.privacyCenter.fullname" .) .Values.privacyCenter.configuration.configFilesOverrideConfigMap }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/fides-minimal/templates/privacy-center/service.yaml
+++ b/fides-minimal/templates/privacy-center/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.privacyCenter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include  "fides.privacyCenter.fullname" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.privacyCenter.service.type }}
+  ports:
+    - port: {{ .Values.privacyCenter.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fides.privacyCenter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/fides-minimal/templates/serviceaccount.yaml
+++ b/fides-minimal/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fides.serviceAccountName" . }}
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/fides-minimal/templates/tests/test-connection.yaml
+++ b/fides-minimal/templates/tests/test-connection.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "fides.fullname" . }}-test"
+  labels:
+    {{- include "fides.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  containers:
+    - name: fides
+      image: {{ printf "%s:%s" .Values.fides.image.repository ( include "fides.dockerTag" .)}}
+      imagePullPolicy: {{ .Values.fides.image.pullPolicy }}
+      env:
+        - name: FIDES__CLI__SERVER_HOST
+          value: {{ include "fides.fullname" . }}
+        - name: FIDES__CLI__SERVER_PORT
+          value: {{ .Values.fides.service.port | quote }}
+        - name: FIDES__USER__ANALYTICS_OPT_OUT
+          value: "true"
+      command: ['fides']
+      args: ['status']
+    - name: privacy-center
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "fides.privacyCenter.fullname" . }}:{{ .Values.privacyCenter.service.port }}']
+  restartPolicy: Never

--- a/fides-minimal/values.yaml
+++ b/fides-minimal/values.yaml
@@ -1,0 +1,148 @@
+# Default values for Fides.
+
+# fides is the main application that runs the Admin UI and API endpoints.
+fides:
+  image:
+    repository: ethyca/fides
+    pullPolicy: IfNotPresent
+    # Overrides the Fides image tag whose default is the chart appVersion.
+    tag: ""
+  configuration:
+    # fides.configuration.dbSecretName is the name of the Kubernetes secret containing the Postgres connection information
+    # This secret should have at least the following keys: DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD, DB_DATABASE. This value is required.
+    dbSecretName: ""
+    # fides.configuration.redisSecretName is the name of the Kubernetes secret containing the Redis connection information
+    # This secret should have at least the following keys: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD. This value is required.
+    redisSecretName: ""
+    # fides.configure.additionalEnvVar adds arbitrary environment variables to the configuration, in addition to those set
+    # by the Helm chart. See https://ethyca.github.io/fides/installation/configuration/ for all possible values.
+    additionalEnvVars:
+      - name: FIDES__LOGGING__LOG_PII
+        value: "false"
+      - name: FIDES__LOGGING__LEVEL # Accepted values include: DEBUG, INFO, WARNING, ERROR, and CRITICAL.
+        value: "INFO"
+      - name: FIDES__EXECUTION__SUBJECT_IDENTITY_VERIFICATION_REQUIRED
+        value: "false"
+      - name: FIDES__EXECUTION__REQUIRE_MANUAL_REQUEST_APPROVAL
+        value: "true"
+      - name: FIDES__USER__ANALYTICS_OPT_OUT
+        value: "true"
+      - name: FIDES__REDIS__SSL
+        value: "false"
+      - name: FIDES__REDIS__SSL_CERT_REQS # Accepted values include: none, optional and require.
+        value: "none"
+      # Additional environment variables may be declared here.
+    # fides.configuration.additionalEnvVarsSecret is an optional parameter representing the name of an existing secret containing environment variables to pass into the Fides containers.
+    additionalEnvVarsSecret: ""
+    # fides.configuration.fidesSecuritySecretName is an optional parameter that respresents the name of a Kubernetes secret containing sensitive Fides configuration elements. If set, this secret must have the following keys:
+    # FIDES__SECURITY__APP_ENCRYPTION_KEY, FIDES__SECURITY__OAUTH_ROOT_CLIENT_ID, FIDES__SECURITY__OAUTH_ROOT_CLIENT_SECRET, FIDES__SECURITY__DRP_JWT_SECRET
+    fidesSecuritySecretName: ""
+    # fides.configuration.additionalCORSOrigins is an optional parameter to configure allowed CORS origins in addition to the Fides and Privacy Center URLs.
+    additionalCORSOrigins: []
+  # fides.publicHostname is used to set the allowed CORS origins for Fides, e.g. fides.example.com
+  publicHostname: ""
+  fullnameOverride: ""
+  service:
+    type: NodePort
+    port: 8080
+  # fides.startupTimeSeconds configures the delay before liveness and readiness probes begin.
+  # For local kubernetes clusters, such as minikube & kind, you may need to increase this value to 60 seconds.
+  startupTimeSeconds: 30
+  # fides.healthCheckTimeoutSeconds configures the timeoutSeconds of the liveness and readiness probes.
+  healthCheckTimeoutSeconds: 5
+  workers:
+    # fides.workers.count determines how many workers the deployment will use to process DSRs.
+    # To disable workers, set count to 0. This should be set to at least 1 in production environments.
+    count: 0
+
+# privacyCenter is the end-user facing application where data subjects can submit privacy requests.
+privacyCenter:
+  # privacyCenter.enabled determines whether a privacy center will be deployed.
+  enabled: true
+  image:
+    repository: ethyca/fides-privacy-center
+    pullPolicy: IfNotPresent
+    # Overrides the Fides Privacy Center image tag whose default is the chart appVersion.
+    tag: ""
+  configuration:
+    # privacyCenter.configuration.configJsonPath specifies the location of the config.json as described in https://ethyca.github.io/fides/ui/privacy_center/.
+    # Note: the value of server_url_production will be overwritten to use the hostname specified by ingress.hosts.fides
+    configJsonPath: config/privacyCenterConfig.json
+    # privacyCenter.configuration.configCSSPath specifies the location of the config.css file to override the default styles.
+    configCSSPath: config/privacyCenterConfig.css
+    # privacyCenter.configuration.configFilesOverride specifies the name of an existing configmap with the keys config.css and config.json containing the customization files.
+    configFilesOverrideConfigMap: ""
+  nameOverride: ""
+  # privacyCenter.publicHostname is used to set the allowed CORS origins for Fides, e.g. privacy.example.com
+  publicHostname: ""
+  fullnameOverride: ""
+  service:
+    type: NodePort
+    port: 3000
+
+nameOverride: ""
+imagePullSecrets: []
+
+# useRollingUpdate helps to minimize upgrade downtime by running deployment upgrades with a RollingUpdate strategy.
+# When useRollingUpdate is set to false, the Recreate strategy is used instead. For production deployments,
+# useRollingUpdate should be set to true.
+useRollingUpdate: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+ingress:
+  enabled: false
+  className: ""
+  installIngressController:
+    # installIngressController.awsLoadBalancerController is an option to install the AWS Load Balancer Controller
+    # as part of this chart.
+    awsLoadBalancerController: false
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  tls: []
+  #  - secretName: fides-tls
+  #    hosts:
+  #      - privacy.example.com
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

This PR creates a new Helm chart (derived from the original Helm chart) without some advanced features such as the `lookup` function. This is mainly to address the issues discovered while deploying Fides with ArgoCD here: https://github.com/argoproj/argo-cd/issues/5202

Note: This probably could have been done in a much more [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) manner by using a library chart to deduplicate the shared portions between the `fides` and `fides-minimal` charts; however this is the fastest and least disruptive to the working `fides` chart.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
