### PR TITLE
Change Worker Health Checks Following Fides Refactor

### DIFF
--- a/fides-minimal/Chart.yaml
+++ b/fides-minimal/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides-minimal
-version: 0.11.2
+version: 0.12.0
 appVersion: "2.14.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code. This version of the Helm chart removes some excess features such as the lookup function which may not be available in all cases, such as ArgoCD.
 type: application

--- a/fides-minimal/templates/fides/worker-deployment.yaml
+++ b/fides-minimal/templates/fides/worker-deployment.yaml
@@ -55,7 +55,7 @@ spec:
               command: [
                 "bash",
                 "-c",
-                "celery --quiet --no-color --app fides.api.ops.tasks inspect ping --destination celery@$HOSTNAME --json"
+                "celery --quiet --no-color --app fides.api.tasks inspect ping --destination celery@$HOSTNAME --json"
               ]
             initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
             periodSeconds: 60

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.11.2
+version: 0.12.0
 appVersion: "2.14.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -55,7 +55,7 @@ spec:
               command: [
                 "bash",
                 "-c",
-                "celery --quiet --no-color --app fides.api.ops.tasks inspect ping --destination celery@$HOSTNAME --json"
+                "celery --quiet --no-color --app fides.api.tasks inspect ping --destination celery@$HOSTNAME --json"
               ]
             initialDelaySeconds: {{ .Values.fides.startupTimeSeconds | default 30 }}
             periodSeconds: 60


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes
Attempted fix for OPS-355

This PR changes the liveness probe for the Fides worker pods to use a new application name in the Celery CLI. This change is necessitated following some refactoring of the Fides code in https://github.com/ethyca/fides/pull/3318.

This change is made in both `fides` and `fides-minimal`.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
