### PR TITLE
Allow for Fides-specific and Privacy-Center-specific Resources

### DIFF
--- a/fides/CHANGELOG.md
+++ b/fides/CHANGELOG.md
@@ -26,6 +26,10 @@ The types of changes are:
 
 ### Changed
 
+## [0.14.0](https://github.com/ethyca/fides-helm/compare/fides-0.14.0...main)
+
+### Changed
+- **Breaking** Resources now specified at the fides and privacyCenter level. [#68](https://github.com/ethyca/fides-helm/pull/68)
 
 ## [0.13.8](https://github.com/ethyca/fides-helm/compare/fides-0.13.7...fides-0.13.8)
 

--- a/fides/CHANGELOG.md
+++ b/fides/CHANGELOG.md
@@ -16,7 +16,7 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fides-helm/compare/fides-0.13.2...main)
+## [Unreleased](https://github.com/ethyca/fides-helm/compare/fides-0.14.0...main)
 
 ### Added
 
@@ -26,7 +26,7 @@ The types of changes are:
 
 ### Changed
 
-## [0.14.0](https://github.com/ethyca/fides-helm/compare/fides-0.14.0...main)
+## [0.14.0](https://github.com/ethyca/fides-helm/compare/fides-0.13.8...fides-0.14.0)
 
 ### Changed
 - **Breaking** Resources now specified at the fides and privacyCenter level. [#68](https://github.com/ethyca/fides-helm/pull/68)

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.13.8
+version: 0.14.0
 appVersion: "2.18.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/templates/fides/fides-deployment.yaml
+++ b/fides/templates/fides/fides-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - name: {{ $volume }}
             mountPath: {{ $configPath }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.fides.resources | nindent 12 }}
       volumes:
         - name: {{ $volume }}
           configMap:

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -64,7 +64,7 @@ spec:
           - name: {{ $volume }}
             mountPath: {{ $configPath }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.fides.resources | nindent 12 }}
       volumes:
         - name: {{ $volume }}
           configMap:

--- a/fides/templates/privacy-center/deployment.yaml
+++ b/fides/templates/privacy-center/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           - name: {{ $volume }}
             mountPath: /app/config
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.privacyCenter.resources | nindent 12 }}
       volumes:
         - name: {{ $volume }}
           configMap:

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -61,10 +61,10 @@ fides:
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     # limits:
     #   cpu: 100m
-    #   memory: 128Mi
+    #   memory: 2048Mi
     # requests:
     #   cpu: 100m
-    #   memory: 128Mi
+    #   memory: 2048Mi
 
 # privacyCenter is the end-user facing application where data subjects can submit privacy requests.
 privacyCenter:
@@ -100,10 +100,10 @@ privacyCenter:
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
     # limits:
     #   cpu: 100m
-    #   memory: 128Mi
+    #   memory: 1024Mi
     # requests:
     #   cpu: 100m
-    #   memory: 128Mi
+    #   memory: 1024Mi
 
 postgresql:
   # postgresql.deployPostgres configures whether to install and configure the Bitnami Postgresql Helm chart

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -56,6 +56,15 @@ fides:
     # fides.workers.count determines how many workers the deployment will use to process DSRs.
     # To disable workers, set count to 0. This should be set to at least 1 in production environments.
     count: 0
+  resources: {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 # privacyCenter is the end-user facing application where data subjects can submit privacy requests.
 privacyCenter:
@@ -86,6 +95,15 @@ privacyCenter:
   service:
     type: NodePort
     port: 3000
+  resources: {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 postgresql:
   # postgresql.deployPostgres configures whether to install and configure the Bitnami Postgresql Helm chart
@@ -151,19 +169,6 @@ ingress:
   #  - secretName: fides-tls
   #    hosts:
   #      - privacy.example.com
-
-resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
 
 nodeSelector: {}
 


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

This PR moves the resources value into two separate values: one for fides/workers and one for the privacy centers.

NOTE: this change requires modification to how the resources in the values.yaml are specified. If you set the `resources` value, be sure to update them to `fides.resources` and `privacyCenter.resources`.

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* ~Relevant Follow-Up Issues Created~
* [x] Update the Fides chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides/CHANGELOG.md)
* ~Update the Fides-minimal chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides-minimal/CHANGELOG.md)~
