### PR TITLE
Mozilla Service Annotations

### DIFF
--- a/fides-minimal/templates/fides/fides-service.yaml
+++ b/fides-minimal/templates/fides/fides-service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "fides.fullname" . }}
   labels:
     {{- include "fides.labels" . | nindent 4 }}
+  {{- with .Values.fides.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.fides.service.type }}
   ports:

--- a/fides/templates/fides/fides-service.yaml
+++ b/fides/templates/fides/fides-service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "fides.fullname" . }}
   labels:
     {{- include "fides.labels" . | nindent 4 }}
+  {{- with .Values.fides.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.fides.service.type }}
   ports:


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
This adds annotations to the Values.fides.service object, allowing ingress annotations when using GKE. This is helpful for situations when you need to leverage:
```
annotations:  
  cloud.google.com/neg: '{"ingress": true}'
```
And other annotations in your environments.

This adds the following to the `fides-service.yaml` in both `fides-minimal/templates/fides/ `and `fides/templates/fides/`:
```
{{- with .Values.fides.service.annotations }}
annotations: {{- toYaml . | nindent 4 }}
{{- end }}
```

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Increment Applicable Chart Versions
* [ ] Relevant Follow-Up Issues Created
* [ ] Update the Fides chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides/CHANGELOG.md)
* [ ] Update the Fides-minimal chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides-minimal/CHANGELOG.md)
