### PR TITLE
feat: Add pod/container security contexts to test-connection pod.

### DIFF
--- a/fides/templates/tests/test-connection.yaml
+++ b/fides/templates/tests/test-connection.yaml
@@ -8,8 +8,12 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 8 }}
   containers:
     - name: fides
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 12 }}
       image: {{ printf "%s:%s" .Values.fides.image.repository ( include "fides.dockerTag" .)}}
       imagePullPolicy: {{ .Values.fides.image.pullPolicy }}
       env:


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes
`test-connection` pod does not use security context defined in the values file. This PR fixes that.

<!--- Replace with your Github Issue --->

<!--- list your code changes here along with any caveats and notes --->

### Pre-merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Increment Applicable Chart Versions
* [ ] Relevant Follow-Up Issues Created
* [ ] Update the Fides chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides/CHANGELOG.md)
* [ ] Update the Fides-minimal chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides-minimal/CHANGELOG.md)
