### PR TITLE
Add configurable worker liveness probe with HTTP option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ The types of changes are:
 
 ### Fixed
 
+## [0.19.0](https://github.com/ethyca/fides-helm/compare/fides-0.18.0...fides-0.19.0)
+
+### Added
+
+- Optional support to use HttpGet health check for the Fides workers instead of Celery
+- New `workerConfiguration` values for liveness probe tuning: `useHttpProbe`, `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`
+
+
 ## [0.18.0](https://github.com/ethyca/fides-helm/compare/fides-0.17.1...fides-0.18.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ The types of changes are:
 - Optional support to use HttpGet health check for the Fides workers instead of Celery
 - New `workerConfiguration` values for liveness probe tuning: `useHttpProbe`, `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, `failureThreshold`
 
+### Changed
+- Upgrade default Fides version to [`2.82.1`]
+
 
 ## [0.18.0](https://github.com/ethyca/fides-helm/compare/fides-0.17.1...fides-0.18.0)
 

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: fides
-version: 0.18.0
+version: 0.19.0
 appVersion: "2.67.0"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application

--- a/fides/Chart.yaml
+++ b/fides/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fides
 version: 0.19.0
-appVersion: "2.67.0"
+appVersion: "2.82.1"
 description: Fides is an open-source privacy engineering platform for managing the fulfillment of data privacy requests in your runtime environment, and the enforcement of privacy regulations in your code.
 type: application
 keywords:

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -105,6 +105,12 @@ spec:
             - secretRef: 
                 name: {{ $.Values.fides.configuration.additionalEnvVarsSecret }}
             {{- end }}
+          {{- if $.Values.fides.workerConfiguration.useHttpProbe }}
+          ports:
+            - name: health
+              containerPort: 9000
+              protocol: TCP
+          {{- end }}
           livenessProbe:
             {{- if $.Values.fides.workerConfiguration.useHttpProbe }}
             httpGet:

--- a/fides/templates/fides/worker-deployment.yaml
+++ b/fides/templates/fides/worker-deployment.yaml
@@ -106,15 +106,22 @@ spec:
                 name: {{ $.Values.fides.configuration.additionalEnvVarsSecret }}
             {{- end }}
           livenessProbe:
+            {{- if $.Values.fides.workerConfiguration.useHttpProbe }}
+            httpGet:
+              path: /
+              port: 9000
+            {{- else }}
             exec:
               command: [
                 "bash",
                 "-c",
                 "celery --quiet --no-color --app fides.api.tasks inspect ping --destination celery@$HOSTNAME --json"
               ]
-            initialDelaySeconds: {{ $.Values.fides.startupTimeSeconds | default 30 }}
-            periodSeconds: 60
-            timeoutSeconds: {{ $.Values.fides.healthCheckTimeoutSeconds | default 5 }}
+            {{- end }}
+            initialDelaySeconds: {{ $.Values.fides.workerConfiguration.initialDelaySeconds | default ($.Values.fides.startupTimeSeconds | default 30) }}
+            periodSeconds: {{ $.Values.fides.workerConfiguration.periodSeconds | default 60 }}
+            timeoutSeconds: {{ $.Values.fides.workerConfiguration.timeoutSeconds | default ($.Values.fides.healthCheckTimeoutSeconds | default 5) }}
+            failureThreshold: {{ $.Values.fides.workerConfiguration.failureThreshold | default 3 }}
           volumeMounts:
           - name: {{ include "fides.configVolume" $ }}
             mountPath: {{ include "fides.configPath" $ }}

--- a/fides/values.yaml
+++ b/fides/values.yaml
@@ -75,6 +75,19 @@ fides:
   # To override defaults, explicitly define workers below. To disable a worker, set count: 0.
   # For more information, see: https://www.ethyca.com/docs/dev-docs/get-started/advanced#running-workers
   workerConfiguration:
+    # useHttpProbe switches the worker liveness probe from a Celery exec command (default)
+    # to an HTTP GET against the in-process health check server on port 9000.
+    # The exec probe spawns a full celery process on each check, which may cause
+    # issues at scale. The HTTP probe avoids that overhead.
+    useHttpProbe: false
+    #
+    # Liveness probe tuning. If not set, falls back to fides.startupTimeSeconds
+    # and fides.healthCheckTimeoutSeconds respectively.
+    # Uncomment to tune these.
+    # initialDelaySeconds: 30
+    # periodSeconds: 60
+    # timeoutSeconds: 5
+    # failureThreshold: 3
     workers: []
     # Example worker override:
     # - name: other


### PR DESCRIPTION
<!--- Please fill out this template in its entirety. --->
### Description of Changes

Summary
Adds useHttpProbe toggle to switch worker liveness probes from the default celery inspect ping exec command to an HTTP GET against the in-process health check server (port `9000`). The exec probe spawns a full Celery CLI process on every check, which may lead to issues when scaling workers.

Exposes `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, and `failureThreshold` as configurable values under the `workerConfiguration` key. These were previously hardcoded or only partially configurable via `fides.startupTimeSeconds` / `fides.healthCheckTimeoutSeconds`.
Fully backwards compatible — defaults match current behavior.

### Pre-merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Increment Applicable Chart Versions
* [x] Relevant Follow-Up Issues Created
* [x] Update the Fides chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides/CHANGELOG.md)
* [ ] Update the Fides-minimal chart [CHANGELOG.md](https://github.com/ethyca/fides-helm/blob/main/fides-minimal/CHANGELOG.md)
